### PR TITLE
project_id assigment and subnet validation

### DIFF
--- a/octavia_proxy/api/v2/controllers/load_balancer.py
+++ b/octavia_proxy/api/v2/controllers/load_balancer.py
@@ -28,7 +28,7 @@ from octavia_proxy.api.drivers import driver_factory
 from octavia_proxy.api.drivers import utils as driver_utils
 from octavia_proxy.api.v2.controllers import base
 from octavia_proxy.api.v2.types import load_balancer as lb_types
-from octavia_proxy.common import constants, validate, utils
+from octavia_proxy.common import constants, validate
 from octavia_proxy.common import exceptions
 from octavia_proxy.i18n import _
 


### PR DESCRIPTION
Closes #82 (make project_id not required param)
Closes #83 (fix network validation when only vip-network-id param passed to api)