### PR TITLE
Adapt to the newest validatetoken middleware

### DIFF
--- a/etc/octavia_proxy.conf
+++ b/etc/octavia_proxy.conf
@@ -21,8 +21,8 @@ log_level = INFO
 # graceful_shutdown_timeout = 60
 #
 [validatetoken]
-auth_url=https://iam.eu-de.otc.t-systems.com
-log_name='token_validate'
+www_authenticate_uri=https://iam.eu-de.otc.t-systems.com
+log_name='validatetoken'
 
 [api_settings]
 bind_host = 0.0.0.0

--- a/octavia_proxy/api/app.py
+++ b/octavia_proxy/api/app.py
@@ -62,7 +62,7 @@ def _wrap_app(app):
 
     if cfg.CONF.api_settings.auth_strategy == constants.KEYSTONE_EXT:
         app = validatetoken_middleware.ValidateToken(
-            app, cfg.CONF.validatetoken)
+            app, cfg.CONF)
 
     app = http_proxy_to_wsgi.HTTPProxyToWSGI(app)
 

--- a/octavia_proxy/common/config.py
+++ b/octavia_proxy/common/config.py
@@ -7,6 +7,8 @@ from oslo_log import log as logging
 
 import openstack
 
+from validatetoken.middleware import validatetoken
+
 from octavia_proxy.common import constants
 from octavia_proxy.common import utils
 from octavia_proxy.i18n import _
@@ -26,13 +28,6 @@ core_opts = [
                     help=_("The hostname Octavia is running on")),
     cfg.StrOpt('octavia_plugins', default='hot_plug_plugin',
                help=_("Name of the controller plugin to use")),
-]
-
-validatetoken_opts = [
-    cfg.StrOpt('auth_url', default='https://iam.eu-de.otc.t-systems.com',
-               help=_('Keystone URL to verify the token')),
-    cfg.StrOpt('log_name', default='validatetoken',
-               help=_("logname")),
 ]
 
 api_opts = [
@@ -126,7 +121,8 @@ core_cli_opts = []
 # Register the configuration options
 cfg.CONF.register_opts(core_opts)
 cfg.CONF.register_opts(api_opts, group='api_settings')
-cfg.CONF.register_opts(validatetoken_opts, group='validatetoken')
+cfg.CONF.register_opts(validatetoken._VALIDATETOKEN_OPTS,
+                       group=validatetoken.VALIDATETOKEN_MIDDLEWARE_GROUP)
 cfg.CONF.register_opts(networking_opts, group='networking')
 
 

--- a/octavia_proxy/common/context.py
+++ b/octavia_proxy/common/context.py
@@ -28,7 +28,8 @@ class Context(common_context.RequestContext):
         self.project_id = token_info['token']['project']['id']
         self.token_info = token_info
 
-        self.token_auth = token.Token(auth_url=CONF.validatetoken.auth_url)
+        self.token_auth = token.Token(
+            auth_url=CONF.validatetoken.www_authenticate_uri)
         self.token_auth.auth_ref = access.create(
             body=token_info,
             auth_token=self.auth_token

--- a/octavia_proxy/tests/functional/api/v2/base.py
+++ b/octavia_proxy/tests/functional/api/v2/base.py
@@ -119,6 +119,9 @@ class BaseAPITest(base.TestCase):
         self.conf.config(
             group='api_settings',
             auth_strategy=constants.KEYSTONE_EXT)
+        self.conf.config(
+            group='validatetoken',
+            www_authenticate_uri='https://iam.eu-de.otc.t-systems.com')
         self.app = self._make_app()
         self._lb = self._create_lb()
 


### PR DESCRIPTION
- reuse validatetoken options
- pass whole config into validatetoken
- set www_authenticate_uri in the tests, cause there is no default now
