### PR TITLE
Bindep

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+texlive-babel-english [doc platform:rpm]

--- a/octavia_proxy/api/common/invocation.py
+++ b/octavia_proxy/api/common/invocation.py
@@ -54,4 +54,16 @@ def driver_invocation(context=None, function=None, is_parallel=True, *params):
         for provider in enabled_providers:
             result.extend(driver_call(provider, context, function, *params))
         LOG.debug(f'{function}, result: {result}')
+    result = remove_duplicated_entries(result)
+    return result
+
+
+def remove_duplicated_entries(entries: list) -> list:
+    result = []
+    temp = {}
+    for index in range(len(entries)):
+        if entries[index].id not in temp.values():
+            temp.update({index: entries[index].id})
+    for key in temp:
+        result.append(entries[key])
     return result


### PR DESCRIPTION
for texlive-babel-english [doc platform:rpm]
to fix:
! Package babel Error: Unknown option `english'. Either you misspelled it (babel) or the language definition file english.ldf was not found.