### PR TITLE
tox: replace deprecated --blacklist-file with --exclude-list

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,6 @@
 - job:
-    name: otc-tox-py39-tips
-    parent: otc-tox-py39
+    name: otc-tox-py311-tips
+    parent: otc-tox-py311
     description: |
       Execute tests with latest dependencies
     required-projects:
@@ -49,7 +49,7 @@
     check:
       jobs:
         - otc-tox-pep8
-        - otc-tox-py39-tips
+        - otc-tox-py311-tips
         - octavia-proxy-build-image
         - tox-functional:
             required-projects:
@@ -58,7 +58,7 @@
     gate:
       jobs:
         - otc-tox-pep8
-        - otc-tox-py39-tips
+        - otc-tox-py311-tips
         - octavia-proxy-upload-image
         - tox-functional:
             required-projects:

--- a/tox.ini
+++ b/tox.ini
@@ -85,5 +85,5 @@ commands =
 
 [testenv:functional]
 # This will use whatever 'basepython' is set to, so the name is ambiguous.
-commands = stestr --test-path ./octavia_proxy/tests/functional run --serial --blacklist-file .stestr.blacklist.functional {posargs}
+commands = stestr --test-path ./octavia_proxy/tests/functional run --serial --exclude-list .stestr.blacklist.functional {posargs}
            stestr slowest


### PR DESCRIPTION
stestr 4.x removed `--blacklist-file`; the replacement flag is `--exclude-list`.

Without this fix `tox -e functional` fails immediately:
```
stestr run: error: unrecognized arguments: --blacklist-file
ERROR: InvocationError for command ... (exited with code 2)
```

Closes the FAILURE seen in check pipeline builds for PR #122.